### PR TITLE
Fixup tests since we're now all async

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 os: osx
-osx_image: xcode10.1
+osx_image: xcode10.2
 script:
   - swift build
-  - swift test
+  - swift test -Xswiftc -DDEBUG

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ To keep SwiftPrometheus as clean and lightweight as possible, there is no way of
 This could look something like this:
 ```swift
 router.get("/metrics") { request -> String in
-    return prom.getMetrics()
+    let promise = req.eventLoop.newPromise(String.self)
+    prom.getMetrics {
+        promise.succeed(result: $0)
+    }
+    return promise.futureResult
 }
 ```
 Here, I used [Vapor](https://github.com/vapor/vapor) syntax, but this will work with any web framework, since it's just returning a plain String.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/MrLotU/SwiftPrometheus.svg?branch=master)](https://travis-ci.com/MrLotU/SwiftPrometheus) [![Swift 4.2](https://img.shields.io/badge/swift-4.2-orange.svg?style=flat)](http://swift.org)
+[![Build Status](https://travis-ci.com/MrLotU/SwiftPrometheus.svg?branch=master)](https://travis-ci.com/MrLotU/SwiftPrometheus) [![Swift 5.0](https://img.shields.io/badge/swift-5.0-orange.svg?style=flat)](http://swift.org)
 
 # SwiftPrometheus, Prometheus client for Swift
 
@@ -13,7 +13,9 @@ For examples, see [main.swift](./Sources/PrometheusExample/main.swift)
 Counters go up, and reset when the process restarts.
 
 ```swift
-let counter = Prometheus.shared.createCounter(forType: Int.self, named: "my_counter")
+let prom = PrometheusClient()
+
+let counter = prom.createCounter(forType: Int.self, named: "my_counter")
 counter.inc() // Increment by 1
 counter.inc(12) // Increment by given value 
 ```
@@ -23,7 +25,9 @@ counter.inc(12) // Increment by given value
 Gauges can go up and down
 
 ```swift
-let gauge = Prometheus.shared.createGauge(forType: Int.self, named: "my_gauge")
+let prom = PrometheusClient()
+
+let gauge = prom.createGauge(forType: Int.self, named: "my_gauge")
 gauge.inc() // Increment by 1
 gauge.dec(19) // Decrement by given value
 gauge.set(12) // Set to a given value
@@ -34,7 +38,9 @@ gauge.set(12) // Set to a given value
 Histograms track the size and number of events in buckets. This allows for aggregatable calculation of quantiles.
 
 ```swift
-let histogram = Prometheus.shared.createHistogram(forType: Double.self, named: "my_histogram")
+let prom = PrometheusClient()
+
+let histogram = prom.createHistogram(forType: Double.self, named: "my_histogram")
 histogram.observe(4.7) // Observe the given value
 ```
 
@@ -43,7 +49,9 @@ histogram.observe(4.7) // Observe the given value
 Summaries track the size and number of events
 
 ```swift
-let summary = Prometheus.shared.createSummary(forType: Double.self, named: "my_summary")
+let prom = PrometheusClient()
+
+let summary = prom.createSummary(forType: Double.self, named: "my_summary")
 summary.observe(4.7) // Observe the given value
 ```
 
@@ -64,7 +72,9 @@ struct MyInfoStruct: MetricLabels {
    }
 }
 
-let info = Prometheus.shared.createInfo(named: "my_info", helpText: "Just some info", labelType: MyInfoStruct.self)
+let prom = PrometheusClient()
+
+let info = prom.createInfo(named: "my_info", helpText: "Just some info", labelType: MyInfoStruct.self)
 
 info.info(MyInfoStruct("def"))
 ```
@@ -78,19 +88,21 @@ struct RouteLabels: MetricLabels {
    var route: String = "*"
 }
 
-let counter = Prometheus.shared.createCounter(forType: Int.self, named: "my_counter", helpText: "Just a counter", withLabelType: RouteLabels.self)
+let prom = PrometheusClient()
+
+let counter = prom.createCounter(forType: Int.self, named: "my_counter", helpText: "Just a counter", withLabelType: RouteLabels.self)
 
 counter.inc(12, .init(route: "/"))
 ```
 
 # Exporting
 
-To keep SwiftPrometheus as clean and leight weitght as possible, there is no way of exporting metrics to Prometheus. All you can do is get a formatted string that Prometheus can use, so you can integrate it in your own Serverside Swift application
+To keep SwiftPrometheus as clean and lightweight as possible, there is no way of exporting metrics directly to Prometheus. Instead, retrieve a formatted string that Prometheus can use, so you can integrate it in your own Serverside Swift application
 
 This could look something like this:
 ```swift
 router.get("/metrics") { request -> String in
-    return Prometheus.shared.getMetrics()
+    return prom.getMetrics()
 }
 ```
 Here, I used [Vapor](https://github.com/vapor/vapor) syntax, but this will work with any web framework, since it's just returning a plain String.
@@ -99,6 +111,6 @@ Here, I used [Vapor](https://github.com/vapor/vapor) syntax, but this will work 
 
 All contributions are most welcome!
 
-If you think of some crazy cool new feature that should be included, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose). Or, if you want to implement it yourself, [fork this repo](https://github.com/MrLotU/SwiftPrometheus/fork) and submit a PR!
+If you think of some cool new feature that should be included, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose). Or, if you want to implement it yourself, [fork this repo](https://github.com/MrLotU/SwiftPrometheus/fork) and submit a PR!
 
 If you find a bug or have issues, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose) explaining your problems. Please include as much information as possible, so it's easier for me to reproduce (Framework, OS, Swift version, terminal output, etc.)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To keep SwiftPrometheus as clean and lightweight as possible, there is no way of
 
 This could look something like this:
 ```swift
-router.get("/metrics") { request -> String in
+router.get("/metrics") { request -> Future<String> in
     let promise = req.eventLoop.newPromise(String.self)
     prom.getMetrics {
         promise.succeed(result: $0)

--- a/Sources/Prometheus/MetricTypes/Counter.swift
+++ b/Sources/Prometheus/MetricTypes/Counter.swift
@@ -67,7 +67,7 @@ public class Counter<NumType: Numeric, Labels: MetricLabels>: Metric, Prometheus
     ///     - amount: Amount to increment the counter with
     ///     - labels: Labels to attach to the value
     ///
-    public func inc(_ amount: NumType = 1, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
+    public func inc(_ amount: NumType = 1, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
@@ -76,7 +76,7 @@ public class Counter<NumType: Numeric, Labels: MetricLabels>: Metric, Prometheus
             } else {
                 self.value += amount
             }
-            done()
+            done(self.value)
         }
     }
     

--- a/Sources/Prometheus/MetricTypes/Counter.swift
+++ b/Sources/Prometheus/MetricTypes/Counter.swift
@@ -67,17 +67,16 @@ public class Counter<NumType: Numeric, Labels: MetricLabels>: Metric, Prometheus
     ///     - amount: Amount to increment the counter with
     ///     - labels: Labels to attach to the value
     ///
-    public func inc(_ amount: NumType = 1, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func inc(_ amount: NumType = 1, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
                 val += amount
                 self.metrics[labels] = val
-                done(val)
             } else {
                 self.value += amount
-                done(self.value)
             }
+            done()
         }
     }
     

--- a/Sources/Prometheus/MetricTypes/Counter.swift
+++ b/Sources/Prometheus/MetricTypes/Counter.swift
@@ -73,10 +73,11 @@ public class Counter<NumType: Numeric, Labels: MetricLabels>: Metric, Prometheus
                 var val = self.metrics[labels] ?? self.initialValue
                 val += amount
                 self.metrics[labels] = val
+                done(val)
             } else {
                 self.value += amount
+                done(self.value)
             }
-            done(self.value)
         }
     }
     

--- a/Sources/Prometheus/MetricTypes/Gauge.swift
+++ b/Sources/Prometheus/MetricTypes/Gauge.swift
@@ -88,16 +88,16 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
     ///
-    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
+    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
                 val += amount
                 self.metrics[labels] = val
-                done()
+                done(val)
             } else {
                 self.value += amount
-                done()
+                done(self.value)
             }
         }
     }
@@ -108,9 +108,9 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
     ///
-    public func inc(_ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
-        self.inc(1, labels) {
-            done()
+    public func inc(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+        self.inc(1, labels) { value in
+            done(value)
         }
     }
     
@@ -121,16 +121,16 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
     ///
-    public func dec(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
+    public func dec(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
                 val -= amount
                 self.metrics[labels] = val
-                done()
+                done(val)
             } else {
                 self.value -= amount
-                done()
+                done(self.value)
             }
         }
     }
@@ -140,9 +140,9 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     /// - Parameters:
     ///     - labels: Labels to attach to the value
     ///
-    public func dec(_ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
-        self.dec(1, labels) {
-            done()
+    public func dec(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+        self.dec(1, labels) { value in
+            done(value)
         }
     }
     

--- a/Sources/Prometheus/MetricTypes/Gauge.swift
+++ b/Sources/Prometheus/MetricTypes/Gauge.swift
@@ -40,8 +40,8 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     
     /// Gets the metric string for this Gauge
     ///
-    /// - Returns:
-    ///     Newline seperated Prometheus formatted metric string
+    /// - Parameters:
+    ///     - done: Callback passing a newline separated Prometheus-formatted metric string
     ///
     public func getMetric(_ done: @escaping (String) -> Void) {
         prometheusQueue.async(flags: .barrier) {
@@ -69,14 +69,14 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - amount: Amount to set the gauge to
     ///     - labels: Labels to attach to the value
     ///
-    public func set(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func set(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 self.metrics[labels] = amount
-                done(amount)
+                done()
             } else {
                 self.value = amount
-                done(self.value)
+                done()
             }
         }
     }
@@ -87,18 +87,17 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - amount: Amount to increment the Gauge with
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
-    ///     - observedValue: Value written to the Gauge
     ///
-    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
                 val += amount
                 self.metrics[labels] = val
-                done(val)
+                done()
             } else {
                 self.value += amount
-                done(self.value)
+                done()
             }
         }
     }
@@ -109,9 +108,9 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
     ///
-    public func inc(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func inc(_ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         self.inc(1, labels) {
-            done($0)
+            done()
         }
     }
     
@@ -122,16 +121,16 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///     - done: Completion handler
     ///
-    public func dec(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func dec(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue
                 val -= amount
                 self.metrics[labels] = val
-                done(val)
+                done()
             } else {
                 self.value -= amount
-                done(self.value)
+                done()
             }
         }
     }
@@ -141,9 +140,9 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     /// - Parameters:
     ///     - labels: Labels to attach to the value
     ///
-    public func dec(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
+    public func dec(_ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         self.dec(1, labels) {
-            done($0)
+            done()
         }
     }
     

--- a/Sources/Prometheus/MetricTypes/Gauge.swift
+++ b/Sources/Prometheus/MetricTypes/Gauge.swift
@@ -109,9 +109,7 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - done: Completion handler
     ///
     public func inc(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
-        self.inc(1, labels) { value in
-            done(value)
-        }
+        self.inc(1, labels, done)
     }
     
     /// Decrements the Gauge
@@ -141,9 +139,7 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - labels: Labels to attach to the value
     ///
     public func dec(_ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
-        self.dec(1, labels) { value in
-            done(value)
-        }
+        self.dec(1, labels, done)
     }
     
     /// Gets the value of the Gauge

--- a/Sources/Prometheus/MetricTypes/Gauge.swift
+++ b/Sources/Prometheus/MetricTypes/Gauge.swift
@@ -89,7 +89,7 @@ public class Gauge<NumType: Numeric, Labels: MetricLabels>: Metric, PrometheusHa
     ///     - done: Completion handler
     ///     - observedValue: Value written to the Gauge
     ///
-    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (_ observedValue: NumType) -> Void = { _ in }) {
+    public func inc(_ amount: NumType, _ labels: Labels? = nil, _ done: @escaping (NumType) -> Void = { _ in }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels {
                 var val = self.metrics[labels] ?? self.initialValue

--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -125,7 +125,7 @@ public class Histogram<NumType: DoubleRepresentable, Labels: HistogramLabels>: M
     ///     - labels: Labels to attach to the observed value
     ///     - done: Completion handler
     ///     - observedValue: Value written to the histogram
-    public func observe(_ value: NumType, _ labels: Labels? = nil, _ done: @escaping (_ observedValue: NumType) -> Void = { _ in }) {
+    public func observe(_ value: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels, type(of: labels) != type(of: EmptySummaryLabels()) {
                 let his = self.prometheus.getOrCreateHistogram(with: labels, for: self)

--- a/Sources/Prometheus/MetricTypes/Info.swift
+++ b/Sources/Prometheus/MetricTypes/Info.swift
@@ -39,8 +39,9 @@ public class Info<Labels: MetricLabels>: Metric, PrometheusHandled {
     
     /// Gets the metric string for this Info
     ///
-    /// - Returns:
-    ///     Newline seperated Prometheus formatted metric string
+    /// - Parameters:
+    ///     - done: Callback passing a newline separated Prometheus-formatted metric string
+    ///
     public func getMetric(_ done: @escaping (String) -> Void) {
         prometheusQueue.async(flags: .barrier) {
             var output = [String]()

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -125,7 +125,7 @@ public class Summary<NumType: DoubleRepresentable, Labels: SummaryLabels>: Metri
     ///     - labels: Labels to attach to the observed value
     ///     - done: Completion handler
     ///     - observedValue: Value written to the summary
-    public func observe(_ value: NumType, _ labels: Labels? = nil, _ done: @escaping (_ observedValue: NumType) -> Void = { _ in }) {
+    public func observe(_ value: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels, type(of: labels) != type(of: EmptySummaryLabels()) {
                 let sum = self.prometheus.getOrCreateSummary(withLabels: labels, forSummary: self)

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -1,5 +1,3 @@
-import Dispatch
-
 /// Default quantiles used by Summaries
 public var defaultQuantiles = [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999]
 

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -76,8 +76,6 @@ public class Summary<NumType: DoubleRepresentable, Labels: SummaryLabels>: Metri
     ///     - done: Completion handler
     ///     - metric: String value in prom-format
     ///
-    /// - Returns:
-    ///     Newline seperated Prometheus formatted metric string
     public func getMetric(_ done: @escaping (_ metric: String) -> Void) {
         prometheusQueue.async(flags: .barrier) {
             var output = [String]()
@@ -124,21 +122,17 @@ public class Summary<NumType: DoubleRepresentable, Labels: SummaryLabels>: Metri
     ///     - value: Value to observe
     ///     - labels: Labels to attach to the observed value
     ///     - done: Completion handler
-    ///     - observedValue: Value written to the summary
+    ///
     public func observe(_ value: NumType, _ labels: Labels? = nil, _ done: @escaping () -> Void = { }) {
         prometheusQueue.async(flags: .barrier) {
             if let labels = labels, type(of: labels) != type(of: EmptySummaryLabels()) {
                 let sum = self.prometheus.getOrCreateSummary(withLabels: labels, forSummary: self)
-                sum.observe(value, nil, done)
+                sum.observe(value)
             }
             self.count.inc(1)
             self.sum.inc(value)
             self.values.append(value)
-
-            // Only run the callback once; not on both the label and without labels
-            if labels == nil {
-                done(value)
-            }
+            done()
         }
     }
 }

--- a/Sources/Prometheus/Utils.swift
+++ b/Sources/Prometheus/Utils.swift
@@ -62,9 +62,9 @@ public protocol DoubleRepresentable: Numeric {
 /// Numbers that convert to other types
 public protocol ConvertibleNumberType: DoubleRepresentable {}
 public extension ConvertibleNumberType {
-    public var floatValue: Float {get {return Float(doubleValue)}}
-    public var intValue: Int {get {return lrint(doubleValue)}}
-    public var CGFloatValue: CGFloat {get {return CGFloat(doubleValue)}}
+    var floatValue: Float {get {return Float(doubleValue)}}
+    var intValue: Int {get {return lrint(doubleValue)}}
+    var CGFloatValue: CGFloat {get {return CGFloat(doubleValue)}}
 }
 
 /// Double Representable Conformance

--- a/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
+++ b/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
@@ -40,12 +40,12 @@ final class SwiftPrometheusTests: XCTestCase {
             self.myValue = myValue
         }
     }
-
     
-    var prom: Prometheus!
+    
+    var prom: PrometheusClient!
     
     override func setUp() {
-        self.prom = Prometheus()
+        self.prom = PrometheusClient()
     }
     
     override func tearDown() {
@@ -53,63 +53,149 @@ final class SwiftPrometheusTests: XCTestCase {
     }
     
     func testCounter() {
+        let semaphore = DispatchSemaphore(value: 0)
+        
         let counter = prom.createCounter(forType: Int.self, named: "my_counter", helpText: "Counter for testing", initialValue: 10, withLabelType: BaseLabels.self)
         XCTAssertEqual(counter.get(), 10)
-        counter.inc(10)
-        XCTAssertEqual(counter.get(), 20)
-        counter.inc(10, BaseLabels(myValue: "labels"))
-        XCTAssertEqual(counter.get(), 20)
+        counter.inc(10) { int in
+            XCTAssertEqual(counter.get(), 20)
+            XCTAssertEqual(int, 20)
+        }
+        counter.inc(10, BaseLabels(myValue: "labels")) { int in
+            XCTAssertEqual(counter.get(), 20)
+            semaphore.signal()
+        }
+        semaphore.wait()
         XCTAssertEqual(counter.get(BaseLabels(myValue: "labels")), 20)
-
-        XCTAssertEqual(counter.getMetric(), "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 20\nmy_counter{myValue=\"labels\"} 20")
+        
+        counter.getMetric { metric in
+            XCTAssertEqual(metric, "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 20\nmy_counter{myValue=\"labels\"} 20")
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
     
     func testGauge() {
+        let semaphore = DispatchSemaphore(value: 0)
+        
         let gauge = prom.createGauge(forType: Int.self, named: "my_gauge", helpText: "Gauge for testing", initialValue: 10, withLabelType: BaseLabels.self)
         XCTAssertEqual(gauge.get(), 10)
-        gauge.inc(10)
+        gauge.inc(10) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
         XCTAssertEqual(gauge.get(), 20)
-        gauge.dec(12)
+        gauge.dec(12) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
         XCTAssertEqual(gauge.get(), 8)
-        gauge.set(20)
-        gauge.inc(10, BaseLabels(myValue: "labels"))
+        gauge.set(20) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        gauge.inc(10, BaseLabels(myValue: "labels")) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
         XCTAssertEqual(gauge.get(), 20)
         XCTAssertEqual(gauge.get(BaseLabels(myValue: "labels")), 20)
         
-        XCTAssertEqual(gauge.getMetric(), "# HELP my_gauge Gauge for testing\n# TYPE my_gauge gauge\nmy_gauge 20\nmy_gauge{myValue=\"labels\"} 20")
+        gauge.getMetric { metric in
+            XCTAssertEqual(metric, "# HELP my_gauge Gauge for testing\n# TYPE my_gauge gauge\nmy_gauge 20\nmy_gauge{myValue=\"labels\"} 20")
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
     
     func testHistogram() {
+        let semaphore = DispatchSemaphore(value: 0)
+
         let histogram = prom.createHistogram(forType: Double.self, named: "my_histogram", helpText: "Histogram for testing", buckets: [0.5, 1, 2, 3, 5, Double.greatestFiniteMagnitude], labels: BaseHistogramLabels.self)
-        histogram.observe(1)
-        histogram.observe(2)
-        histogram.observe(3)
+        histogram.observe(1) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        histogram.observe(2) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        histogram.observe(3) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
         
-        histogram.observe(3, .init(myValue: "labels"))
-        
-        XCTAssertEqual(histogram.getMetric(), "# HELP my_histogram Histogram for testing\n# TYPE my_histogram histogram\nmy_histogram_bucket{myValue=\"*\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"*\", le=\"1.0\"} 1.0\nmy_histogram_bucket{myValue=\"*\", le=\"2.0\"} 2.0\nmy_histogram_bucket{myValue=\"*\", le=\"3.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"5.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"+Inf\"} 4.0\nmy_histogram_count{myValue=\"*\"} 4.0\nmy_histogram_sum{myValue=\"*\"} 9.0\nmy_histogram_bucket{myValue=\"labels\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"1.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"2.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"3.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"5.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"+Inf\"} 1.0\nmy_histogram_count{myValue=\"labels\"} 1.0\nmy_histogram_sum{myValue=\"labels\"} 3.0")
+        histogram.observe(3, .init(myValue: "labels")) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+        var metricOutput = ""
+        histogram.getMetric { metric in
+            metricOutput = metric
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        XCTAssertEqual(metricOutput, "# HELP my_histogram Histogram for testing\n# TYPE my_histogram histogram\nmy_histogram_bucket{myValue=\"*\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"*\", le=\"1.0\"} 1.0\nmy_histogram_bucket{myValue=\"*\", le=\"2.0\"} 2.0\nmy_histogram_bucket{myValue=\"*\", le=\"3.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"5.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"+Inf\"} 4.0\nmy_histogram_count{myValue=\"*\"} 4.0\nmy_histogram_sum{myValue=\"*\"} 9.0\nmy_histogram_bucket{myValue=\"labels\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"1.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"2.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"3.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"5.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"+Inf\"} 1.0\nmy_histogram_count{myValue=\"labels\"} 1.0\nmy_histogram_sum{myValue=\"labels\"} 3.0")
     }
     
     func testInfo() {
         let info = prom.createInfo(named: "my_info", helpText: "Info for testing", labelType: BaseLabels.self)
         info.info(.init(myValue: "testing"))
         
-        XCTAssertEqual(info.getMetric(), "# HELP my_info Info for testing\n# TYPE my_info info\nmy_info{myValue=\"testing\"} 1.0")
+        let semaphore = DispatchSemaphore(value: 0)
+        info.getMetric { metric in
+            XCTAssertEqual(metric, "# HELP my_info Info for testing\n# TYPE my_info info\nmy_info{myValue=\"testing\"} 1.0")
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
     
     func testSummary() {
         let summary = prom.createSummary(forType: Double.self, named: "my_summary", helpText: "Summary for testing", quantiles: [0.5, 0.9, 0.99], labels: BaseSummaryLabels.self)
+        let semaphore = DispatchSemaphore(value: 0)
         
-        summary.observe(1)
-        summary.observe(2)
-        summary.observe(4)
-        summary.observe(10000)
-        
-        summary.observe(123, .init(myValue: "labels"))
-        
-        XCTAssertEqual(summary.getMetric(), "# HELP my_summary Summary for testing\n# TYPE my_summary summary\nmy_summary{quantile=\"0.5\", myValue=\"*\"} 4.0\nmy_summary{quantile=\"0.9\", myValue=\"*\"} 10000.0\nmy_summary{quantile=\"0.99\", myValue=\"*\"} 10000.0\nmy_summary_count{myValue=\"*\"} 5.0\nmy_summary_sum{myValue=\"*\"} 10130.0\nmy_summary{quantile=\"0.5\", myValue=\"labels\"} 123.0\nmy_summary{quantile=\"0.9\", myValue=\"labels\"} 123.0\nmy_summary{quantile=\"0.99\", myValue=\"labels\"} 123.0\nmy_summary_count{myValue=\"labels\"} 1.0\nmy_summary_sum{myValue=\"labels\"} 123.0")
-    }
+        summary.observe(1) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
 
+        summary.observe(2) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        summary.observe(4) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        summary.observe(10000) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+        
+        summary.observe(123, .init(myValue: "labels")) { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+        
+        var outputMetric = ""
+        summary.getMetric { metric in
+            outputMetric = metric
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        XCTAssertEqual(outputMetric, "# HELP my_summary Summary for testing\n# TYPE my_summary summary\nmy_summary{quantile=\"0.5\", myValue=\"*\"} 4.0\nmy_summary{quantile=\"0.9\", myValue=\"*\"} 10000.0\nmy_summary{quantile=\"0.99\", myValue=\"*\"} 10000.0\nmy_summary_count{myValue=\"*\"} 5.0\nmy_summary_sum{myValue=\"*\"} 10130.0\nmy_summary{quantile=\"0.5\", myValue=\"labels\"} 123.0\nmy_summary{quantile=\"0.9\", myValue=\"labels\"} 123.0\nmy_summary{quantile=\"0.99\", myValue=\"labels\"} 123.0\nmy_summary_count{myValue=\"labels\"} 1.0\nmy_summary_sum{myValue=\"labels\"} 123.0")
+    }
+    
     static var allTests = [
         ("testCounter", testCounter),
         ("testGauge", testGauge),

--- a/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
+++ b/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
@@ -57,13 +57,15 @@ final class SwiftPrometheusTests: XCTestCase {
         
         let counter = prom.createCounter(forType: Int.self, named: "my_counter", helpText: "Counter for testing", initialValue: 10, withLabelType: BaseLabels.self)
         XCTAssertEqual(counter.get(), 10)
-        counter.inc(10) {
+        counter.inc(10) { value in
+            XCTAssertEqual(value, 20)
             semaphore.signal()
         }
         semaphore.wait()
         XCTAssertEqual(counter.get(), 20)
 
-        counter.inc(10, BaseLabels(myValue: "labels")) {
+        counter.inc(10, BaseLabels(myValue: "labels")) { value in
+            XCTAssertEqual(value, 20)
             semaphore.signal()
         }
         semaphore.wait()
@@ -82,13 +84,15 @@ final class SwiftPrometheusTests: XCTestCase {
         
         let gauge = prom.createGauge(forType: Int.self, named: "my_gauge", helpText: "Gauge for testing", initialValue: 10, withLabelType: BaseLabels.self)
         XCTAssertEqual(gauge.get(), 10)
-        gauge.inc(10) {
+        gauge.inc(10) { value in
+            XCTAssertEqual(value, 20)
             semaphore.signal()
         }
         semaphore.wait()
 
         XCTAssertEqual(gauge.get(), 20)
-        gauge.dec(12) {
+        gauge.dec(12) { value in
+            XCTAssertEqual(value, 8)
             semaphore.signal()
         }
         semaphore.wait()
@@ -99,7 +103,8 @@ final class SwiftPrometheusTests: XCTestCase {
         }
         semaphore.wait()
 
-        gauge.inc(10, BaseLabels(myValue: "labels")) {
+        gauge.inc(10, BaseLabels(myValue: "labels")) { value in
+            XCTAssertEqual(value, 20)
             semaphore.signal()
         }
         semaphore.wait()


### PR DESCRIPTION
The API is now always running against an async `DispatchQueue`; so we want the tests to verify that process works as expected. I added a callback to both the `Summary` and `Histogram` so we could toggle a `DispatchSemaphore`, which seemed like the easiest path for syncronization.

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

### Motivation and Context
The tests should now be working as expected.

### Test Run

```
jmsmith@SFO-M-JMSMITH01 ~/w/g/M/SwiftPrometheus (master)> swift test                           10:26:37
[5/5] Linking ./.build/x86_64-apple-macosx/debug/SwiftPrometheusPackageTests.xctest/Contents/MacOS/S…
Test Suite 'All tests' started at 2019-04-15 10:27:25.485
Test Suite 'SwiftPrometheusPackageTests.xctest' started at 2019-04-15 10:27:25.485
Test Suite 'SwiftPrometheusTests' started at 2019-04-15 10:27:25.485
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testCounter]' started.
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testCounter]' passed (0.174 seconds).
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testGauge]' started.
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testGauge]' passed (0.000 seconds).
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testHistogram]' started.
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testHistogram]' passed (0.001 seconds).
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testInfo]' started.
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testInfo]' passed (0.000 seconds).
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testSummary]' started.
Test Case '-[SwiftPrometheusTests.SwiftPrometheusTests testSummary]' passed (0.001 seconds).
Test Suite 'SwiftPrometheusTests' passed at 2019-04-15 10:27:25.662.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.177 (0.177) seconds
Test Suite 'SwiftPrometheusPackageTests.xctest' passed at 2019-04-15 10:27:25.662.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.177 (0.177) seconds
Test Suite 'All tests' passed at 2019-04-15 10:27:25.663.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.177 (0.177) seconds
```