### PR TITLE
👯‍♀️ Merge Prometheus and PrometheusMetrics targets into one library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,9 @@ let package = Package(
         .library(
             name: "SwiftPrometheus",
             targets: ["Prometheus"]),
+        .executable(
+            name: "PrometheusExample",
+            targets: ["PrometheusExample"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0"),
@@ -16,15 +19,12 @@ let package = Package(
     targets: [
         .target(
             name: "Prometheus",
-            dependencies: ["NIOConcurrencyHelpers"]),
-        .target(
-            name: "PrometheusMetrics",
-            dependencies: ["Prometheus", "CoreMetrics"]),
+            dependencies: ["CoreMetrics", "NIOConcurrencyHelpers"]),
         .target(
             name: "PrometheusExample",
-            dependencies: ["PrometheusMetrics", "Metrics"]),
+            dependencies: ["Prometheus", "Metrics"]),
         .testTarget(
             name: "SwiftPrometheusTests",
-            dependencies: ["Prometheus", "PrometheusMetrics"]),
+            dependencies: ["Prometheus"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Counters go up (they can only increase in value), and reset when the process res
 let counter = myProm.createCounter(forType: Int.self, named: "my_counter")
 counter.inc() // Increment by 1
 counter.inc(12) // Increment by given value
-counter.reset() // Set the value back to 0
 ```
 
 ## Gauge
@@ -75,30 +74,6 @@ Summaries track the size and number of events
 ```swift
 let summary = myProm.createSummary(forType: Double.self, named: "my_summary")
 summary.observe(4.7) // Observe the given value
-```
-
-## Info
-
-Info tracks key-value information, usually about a whole target. These are typically helpful details like git sha or other metadata.
-
-```swift
-struct MyInfoStruct: MetricLabels {
-   let value: String
-
-   init() {
-       self.value = "abc"
-   }
-
-   init(_ v: String) {
-       self.value = v
-   }
-}
-
-let info = myProm.createInfo(named: "my_info", helpText: "Just some info", labelType: MyInfoStruct.self)
-
-let info = prom.createInfo(named: "my_info", helpText: "Just some info", labelType: MyInfoStruct.self)
-
-info.info(MyInfoStruct("def"))
 ```
 
 ## Labels

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ counter.reset() // Set the value back to 0
 
 ## Gauge
 
-Gauges can go up and down, they represent a "point-in-time" snapshot of a value. This is similar to the sppedometer of a car.
+Gauges can go up and down, they represent a "point-in-time" snapshot of a value. This is similar to the speedometer of a car.
 
 ```swift
 let gauge = myProm.createGauge(forType: Int.self, named: "my_gauge")

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ counter.inc(12, .init(route: "/"))
 
 # Exporting
 
-Prometheus itself is designed to "pull" metrics from a destination. Following this pattern, SwiftPrometheus is designed to expose metrics, as opposed to submitted/exporting them directly to Prometheus itself. Instead, SwiftPrometheus produces a formatted string that Prometheus can parse, which can be integrated into your own application.
+Prometheus itself is designed to "pull" metrics from a destination. Following this pattern, SwiftPrometheus is designed to expose metrics, as opposed to submitted/exporting them directly to Prometheus itself. SwiftPrometheus produces a formatted string that Prometheus can parse, which can be integrated into your own application.
 
 By default, this should be accessible on your main serving port, at the `/metrics` endpoint. An example in [Vapor](https://vapor.codes) syntax looks like:
 

--- a/Sources/Prometheus/PrometheusMetrics.swift
+++ b/Sources/Prometheus/PrometheusMetrics.swift
@@ -1,4 +1,3 @@
-import Prometheus
 import CoreMetrics
 
 private class MetricsCounter: CounterHandler {

--- a/Sources/PrometheusExample/main.swift
+++ b/Sources/PrometheusExample/main.swift
@@ -1,7 +1,5 @@
 import Prometheus
 import Metrics
-import PrometheusMetrics
-import Foundation
 
 let myProm = PrometheusClient()
 

--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import Prometheus
 @testable import CoreMetrics
-@testable import PrometheusMetrics
 
 final class PrometheusMetricsTests: XCTestCase {
     


### PR DESCRIPTION
This is following discussion in #5.

As a library author and application developer, I'd find this much simpler to use if I'm only working with one library since I expect this functionality to be present.

Very open-minded to improvements or suggested tweaks, however!

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

### Motivation and Context
We want to provide a simple solution for end-users to take advantage of. `swift-metrics` has broad applicability across the community, and is already included in the dependency graph. If a user does not wish to use `swift-metrics` they don't need to, but this change will make it much clearer how to do so.

This fixes #5.

### Description

I moved `PrometheusMetrics` into the `Prometheus` target, which composes `SwiftPrometheus`.

In addition, I created a `PrometheusExample` executable to make it easier for users to see the output format and follow along with the code (particularly from within Xcode 🔨 ).