### PR TITLE
Do not recreate a new counter if we already have one.

### DIFF
--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -14,7 +14,7 @@ extension SummaryLabels {
     }
 }
 
-/// Prometheus Counter metric
+/// Prometheus Summary metric
 ///
 /// See https://prometheus.io/docs/concepts/metric_types/#summary
 public class PromSummary<NumType: DoubleRepresentable, Labels: SummaryLabels>: PromMetric, PrometheusHandled {

--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -5,7 +5,7 @@ import NIO
 ///
 /// See https://prometheus.io/docs/introduction/overview/
 public class PrometheusClient {
-    
+
     /// Metrics tracked by this Prometheus instance
     private var metrics: [PromMetric]
     
@@ -109,7 +109,6 @@ public class PrometheusClient {
             if let type = metricTypeMap[name] {
                 precondition(type == .counter, "Label \(name) was associated with \(type) before. Can not be used for a counter now.")
             }
-
             let counter = PromCounter<T, U>(name, helpText, initialValue, self)
             self.metricTypeMap[name] = .counter
             self.metrics.append(counter)
@@ -154,6 +153,10 @@ public class PrometheusClient {
         initialValue: T = 0,
         withLabelType labelType: U.Type) -> PromGauge<T, U>
     {
+        if let gauge: PromGauge<T, U> = getMetricInstance(with: name, andType: .gauge) {
+            return gauge
+        }
+
         return self.lock.withLock {
             if let type = metricTypeMap[name] {
                 precondition(type == .gauge, "Label \(name) was associated with \(type) before. Can not be used for a gauge now.")
@@ -202,6 +205,10 @@ public class PrometheusClient {
         buckets: [Double] = Prometheus.defaultBuckets,
         labels: U.Type) -> PromHistogram<T, U>
     {
+        if let histogram: PromHistogram<T, U> = getMetricInstance(with: name, andType: .histogram) {
+            return histogram
+        }
+
         return self.lock.withLock {
             if let type = metricTypeMap[name] {
                 precondition(type == .histogram, "Label \(name) was associated with \(type) before. Can not be used for a histogram now.")
@@ -250,6 +257,10 @@ public class PrometheusClient {
         quantiles: [Double] = Prometheus.defaultQuantiles,
         labels: U.Type) -> PromSummary<T, U>
     {
+        if let summary: PromSummary<T, U> = getMetricInstance(with: name, andType: .summary) {
+            return summary
+        }
+
         return self.lock.withLock {
             if let type = metricTypeMap[name] {
                 precondition(type == .summary, "Label \(name) was associated with \(type) before. Can not be used for a summary now.")

--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -101,10 +101,15 @@ public class PrometheusClient {
         initialValue: T = 0,
         withLabelType labelType: U.Type) -> PromCounter<T, U>
     {
+        if let counter: PromCounter<T, U> = getMetricInstance(with: name, andType: .counter) {
+            return counter
+        }
+
         return self.lock.withLock {
             if let type = metricTypeMap[name] {
                 precondition(type == .counter, "Label \(name) was associated with \(type) before. Can not be used for a counter now.")
             }
+
             let counter = PromCounter<T, U>(name, helpText, initialValue, self)
             self.metricTypeMap[name] = .counter
             self.metrics.append(counter)

--- a/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
+++ b/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
@@ -62,6 +62,22 @@ final class SwiftPrometheusTests: XCTestCase {
         
         XCTAssertEqual(counter.collect(), "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 20\nmy_counter{myValue=\"labels\"} 20")
     }
+
+    func testMultipleCounter() {
+        let counter = prom.createCounter(forType: Int.self, named: "my_counter", helpText: "Counter for testing", initialValue: 10, withLabelType: BaseLabels.self)
+        counter.inc(10)
+        XCTAssertEqual(counter.get(), 20)
+
+        let counterTwo = prom.createCounter(forType: Int.self, named: "my_counter", helpText: "Counter for testing", initialValue: 10, withLabelType: BaseLabels.self)
+        counter.inc(10)
+        XCTAssertEqual(counterTwo.get(), 30)
+        counterTwo.inc(20, BaseLabels(myValue: "labels"))
+
+        XCTAssertEqual(counter.collect(), "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 30\nmy_counter{myValue=\"labels\"} 30")
+        self.prom.collect { metricsString in
+            XCTAssertEqual(metricsString, "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 30\nmy_counter{myValue=\"labels\"} 30")
+        }
+    }
     
     func testGauge() {
         let gauge = prom.createGauge(forType: Int.self, named: "my_gauge", helpText: "Gauge for testing", initialValue: 10, withLabelType: BaseLabels.self)

--- a/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
+++ b/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
@@ -90,28 +90,37 @@ final class SwiftPrometheusTests: XCTestCase {
         gauge.inc(10, BaseLabels(myValue: "labels"))
         XCTAssertEqual(gauge.get(), 20)
         XCTAssertEqual(gauge.get(BaseLabels(myValue: "labels")), 20)
+
+        let gaugeTwo = prom.createGauge(forType: Int.self, named: "my_gauge", helpText: "Gauge for testing", initialValue: 10, withLabelType: BaseLabels.self)
+        XCTAssertEqual(gaugeTwo.get(), 20)
+        gaugeTwo.inc()
+        XCTAssertEqual(gauge.get(), 21)
+        XCTAssertEqual(gaugeTwo.get(), 21)
         
-        XCTAssertEqual(gauge.collect(), "# HELP my_gauge Gauge for testing\n# TYPE my_gauge gauge\nmy_gauge 20\nmy_gauge{myValue=\"labels\"} 20")
+        XCTAssertEqual(gauge.collect(), "# HELP my_gauge Gauge for testing\n# TYPE my_gauge gauge\nmy_gauge 21\nmy_gauge{myValue=\"labels\"} 20")
     }
     
     func testHistogram() {
         let histogram = prom.createHistogram(forType: Double.self, named: "my_histogram", helpText: "Histogram for testing", buckets: [0.5, 1, 2, 3, 5, Double.greatestFiniteMagnitude], labels: BaseHistogramLabels.self)
+        let histogramTwo = prom.createHistogram(forType: Double.self, named: "my_histogram", helpText: "Histogram for testing", buckets: [0.5, 1, 2, 3, 5, Double.greatestFiniteMagnitude], labels: BaseHistogramLabels.self)
+
         histogram.observe(1)
         histogram.observe(2)
-        histogram.observe(3)
+        histogramTwo.observe(3)
         
         histogram.observe(3, .init(myValue: "labels"))
-        
+
         XCTAssertEqual(histogram.collect(), "# HELP my_histogram Histogram for testing\n# TYPE my_histogram histogram\nmy_histogram_bucket{myValue=\"*\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"*\", le=\"1.0\"} 1.0\nmy_histogram_bucket{myValue=\"*\", le=\"2.0\"} 2.0\nmy_histogram_bucket{myValue=\"*\", le=\"3.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"5.0\"} 4.0\nmy_histogram_bucket{myValue=\"*\", le=\"+Inf\"} 4.0\nmy_histogram_count{myValue=\"*\"} 4.0\nmy_histogram_sum{myValue=\"*\"} 9.0\nmy_histogram_bucket{myValue=\"labels\", le=\"0.5\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"1.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"2.0\"} 0.0\nmy_histogram_bucket{myValue=\"labels\", le=\"3.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"5.0\"} 1.0\nmy_histogram_bucket{myValue=\"labels\", le=\"+Inf\"} 1.0\nmy_histogram_count{myValue=\"labels\"} 1.0\nmy_histogram_sum{myValue=\"labels\"} 3.0")
     }
     
     func testSummary() {
         let summary = prom.createSummary(forType: Double.self, named: "my_summary", helpText: "Summary for testing", quantiles: [0.5, 0.9, 0.99], labels: BaseSummaryLabels.self)
+        let summaryTwo = prom.createSummary(forType: Double.self, named: "my_summary", helpText: "Summary for testing", quantiles: [0.5, 0.9, 0.99], labels: BaseSummaryLabels.self)
         
         summary.observe(1)
         summary.observe(2)
         summary.observe(4)
-        summary.observe(10000)
+        summaryTwo.observe(10000)
         
         summary.observe(123, .init(myValue: "labels"))
         


### PR DESCRIPTION
### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [ ] I've updated the documentation if necessary.

### Motivation and Context
We want to make sure we're _reusing_ metrics, not losing ones we already create.

### Description

I discovered when running a service that I'm getting multiple invocations of the same metric appearing when I `collect()`:

```
# TYPE invocation_register counter
invocation_register 0
invocation_register{tool="simple-curl"} 1
# TYPE invocation_register counter
invocation_register 0
invocation_register{tool="simple-curl"} 1
# TYPE invocation_register counter
invocation_register 0
invocation_register{tool="simple-curl"} 1
```

I'm calling [`createCounter`](https://github.com/Yasumoto/emergency-stop/pull/3/files#diff-e579ad4a0b1db41bb8b074fbd630b234R67) on each request based [on the good advice I got here](https://github.com/apple/swift-metrics/issues/38#issuecomment-511760602) from @ktoso.

If this looks roughly right to y'all, I can update the other types to follow this pattern, though definitely open to feedback 🎉 