### PR TITLE
Fix missing newline between metrics when collecting #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 build/
 .swiftpm/
+.idea

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "8e5110dcd6584ff5acfec40e31263a8d07cba783",
-          "version": "1.1.0"
+          "revision": "3fefedaaef285830cc98ae80231140122076a7e0",
+          "version": "1.2.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6a79d4687ede7c088fe3e31d9b3452d6e6cd91eb",
-          "version": "2.5.1"
+          "revision": "9201908b54578aa33f1d1826a5a680aca8991843",
+          "version": "2.8.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -121,4 +121,3 @@ All contributions are most welcome!
 If you think of some cool new feature that should be included, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose). Or, if you want to implement it yourself, [fork this repo](https://github.com/MrLotU/SwiftPrometheus/fork) and submit a PR!
 
 If you find a bug or have issues, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose) explaining your problems. Please include as much information as possible, so it's easier for me to reproduce (Framework, OS, Swift version, terminal output, etc.)
-

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ All contributions are most welcome!
 If you think of some cool new feature that should be included, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose). Or, if you want to implement it yourself, [fork this repo](https://github.com/MrLotU/SwiftPrometheus/fork) and submit a PR!
 
 If you find a bug or have issues, please [create an issue](https://github.com/MrLotU/SwiftPrometheus/issues/new/choose) explaining your problems. Please include as much information as possible, so it's easier for me to reproduce (Framework, OS, Swift version, terminal output, etc.)
+

--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -52,6 +52,7 @@ public class PrometheusClient {
             var buffer = ByteBufferAllocator().buffer(capacity: 0)
             self.metrics.forEach {
                 $0.collect(into: &buffer)
+                buffer.writeString("\n")
             }
             succeed(buffer)
         }

--- a/Tests/SwiftPrometheusTests/XCTestManifests.swift
+++ b/Tests/SwiftPrometheusTests/XCTestManifests.swift
@@ -6,6 +6,9 @@ extension PrometheusMetricsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__PrometheusMetricsTests = [
+        ("testCollectAFewMetricsIntoBuffer", testCollectAFewMetricsIntoBuffer),
+        ("testCollectAFewMetricsIntoString", testCollectAFewMetricsIntoString),
+        ("testCollectIntoBuffer", testCollectIntoBuffer),
         ("testCounter", testCounter),
         ("testGauge", testGauge),
         ("testHistogram", testHistogram),


### PR DESCRIPTION
Resolves #15

### Motivation and Context

I've tried out the backend in a real project and noticed that collecting breaks -- a missing \n between metrics. See #15

Newlines must be inserted between metrics otherwise parsing fails.

The other implementation of collect does it right, since it does `succeed(self.metrics.map { $0.collect() }.joined(separator: "\n"))`

The trailing newline is not an issue, so let's go with this rather than reinventing joined manually IMHO