### PR TITLE
Fix vapor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ Prometheus itself is designed to "pull" metrics from a destination. Following th
 By default, this should be accessible on your main serving port, at the `/metrics` endpoint. An example in [Vapor](https://vapor.codes) syntax looks like:
 
 ```swift
-router.get("/metrics") { request -> String in
-    return myProm.collect()
+router.get("/metrics") { request -> EventLoopFuture<String> in
+    let promise = request.eventLoop.newPromise(of: String.self)
+    myProm.collect(into: promise)
+    return promise.futureResult
 }
 ```
 


### PR DESCRIPTION
(Since I only updated the README, I skip the checks.)

I fixed the example for using SwiftPrometheus in Vapor. Since there is no function `collect()`, which returns a `String`, we need to prepare a promise in order to collect the data.
This is also the way, the `PrometheusExample` prints the metrics.