### PR TITLE
Update SwiftPrometheus to use SwiftMetric 2.* (TimeUnit change to struct)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3fefedaaef285830cc98ae80231140122076a7e0",
-          "version": "1.2.0"
+          "revision": "708b960b4605abb20bc55d65abf6bad607252200",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["PrometheusExample"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.2.0"),
+		.package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["PrometheusExample"]),
     ],
     dependencies: [
-		.package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -1,5 +1,5 @@
 import NIOConcurrencyHelpers
-import enum CoreMetrics.TimeUnit
+import struct CoreMetrics.TimeUnit
 import Dispatch
 
 /// Label type Summaries can use
@@ -125,16 +125,10 @@ public class PromSummary<NumType: DoubleRepresentable, Labels: SummaryLabels>: P
         }
     }
     
+	// Updated for SwiftMetrics 2.0 to be unit agnostic if displayUnit is set or default to nanoseconds.
     private func format(_ v: Double) -> Double {
-        guard let displayUnit = self.displayUnit else { return v }
-        switch displayUnit {
-        case .days: return (v / 1_000_000_000) * 60 * 60 * 24
-        case .hours: return (v / 1_000_000_000) * 60 * 60
-        case .minutes: return (v / 1_000_000_000) * 60
-        case .seconds: return v / 1_000_000_000
-        case .milliseconds: return v / 1_000_000
-        case .nanoseconds: return v
-        }
+		let displayUnitScale = self.displayUnit?.scaleFromNanoseconds ?? 1
+		return v / Double(displayUnitScale)
     }
     
     internal func preferDisplayUnit(_ unit: TimeUnit) {

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -125,10 +125,10 @@ public class PromSummary<NumType: DoubleRepresentable, Labels: SummaryLabels>: P
         }
     }
     
-	// Updated for SwiftMetrics 2.0 to be unit agnostic if displayUnit is set or default to nanoseconds.
+    // Updated for SwiftMetrics 2.0 to be unit agnostic if displayUnit is set or default to nanoseconds.
     private func format(_ v: Double) -> Double {
-		let displayUnitScale = self.displayUnit?.scaleFromNanoseconds ?? 1
-		return v / Double(displayUnitScale)
+        let displayUnitScale = self.displayUnit?.scaleFromNanoseconds ?? 1
+        return v / Double(displayUnitScale)
     }
     
     internal func preferDisplayUnit(_ unit: TimeUnit) {

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -77,7 +77,7 @@ final class SummaryTests: XCTestCase {
         summary.recordSeconds(1)
         summary.recordMilliseconds(2 * 1_000)
         summary.recordMicroseconds(3 * 1_000_000)
-		summary.recordNanoseconds(4 * 1_000_000_000)
+        summary.recordNanoseconds(4 * 1_000_000_000)
         summary.recordSeconds(10000)
 
         let promise = self.eventLoop.makePromise(of: String.self)

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -76,7 +76,8 @@ final class SummaryTests: XCTestCase {
         
         summary.recordSeconds(1)
         summary.recordMilliseconds(2 * 1_000)
-        summary.recordNanoseconds(4 * 1_000_000_000)
+        summary.recordMicroseconds(3 * 1_000_000)
+		summary.recordNanoseconds(4 * 1_000_000_000)
         summary.recordSeconds(10000)
 
         let promise = self.eventLoop.makePromise(of: String.self)
@@ -91,8 +92,8 @@ final class SummaryTests: XCTestCase {
         my_summary{quantile="0.95"} 10000.0
         my_summary{quantile="0.99"} 10000.0
         my_summary{quantile="0.999"} 10000.0
-        my_summary_count 4
-        my_summary_sum 10007.0
+        my_summary_count 5
+        my_summary_sum 10010.0
         """)
     }
     


### PR DESCRIPTION

<!-- 🚀 Thank you for contributing! --->

Updates SwiftPrometheus to depend on SwiftMetrics 2.0.

### Checklist
- [X] The provided tests still run.
- [X] I've created new tests where needed.
- [ ] I've updated the documentation if necessary.

* note - only unit test change is to verify microsecond display works

### Motivation and Context
Change of TimeUnit in SwiftMetrics from enum to struct allows arbitrary addition of time unit scales in future usage.

Removes timeUnit display switching on an enum as the struct version, if used to preference things, doesn't require knowledge of what unit is set.

Addresses Issue https://github.com/MrLotU/SwiftPrometheus/issues/30 but doesn't support both 1.* and 2.* releases, only 2.*

### Description
Switches import of TimeUnit 
XCTest units