### PR TITLE
Prevent the compiler finding the wrong CGFloat

### DIFF
--- a/Sources/Prometheus/Utils.swift
+++ b/Sources/Prometheus/Utils.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if os(iOS) || os(watchOS) || os(tvOS)
+import CoreGraphics
+#endif
+
 /// Empty labels class
 public struct EmptyLabels: MetricLabels {
     /// Creates empty labels


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

As open on this [Issue](https://github.com/MrLotU/SwiftPrometheus/issues/33), this small PR allows to use the library on iOS, WatchOS and tvOS. 


### Checklist
- [x] The provided tests still run.
- [ ] I've created new tests where needed.
- [ ] I've updated the documentation if necessary.

### Motivation and Context

Then we can use the library on iOS, the issue is this [one](https://github.com/MrLotU/SwiftPrometheus/issues/33)

### Description

Adding a compiler flag, to import CoreGraphics will fix the compiler getting crazy of which CGFloat to use. 
