### PR TITLE
Remove CoreGraphics

### DIFF
--- a/Sources/Prometheus/Utils.swift
+++ b/Sources/Prometheus/Utils.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-#if os(iOS) || os(watchOS) || os(tvOS)
-import CoreGraphics
-#endif
-
 /// Empty labels class
 public struct EmptyLabels: MetricLabels {
     /// Creates empty labels
@@ -90,8 +86,6 @@ extension FixedWidthInteger {
 
 /// Double Representable Conformance
 extension Double: ConvertibleNumberType { public var doubleValue: Double { return self }}
-/// Double Representable Conformance
-extension CGFloat: ConvertibleNumberType { public var doubleValue: Double { return Double(self) }}
 /// Double Representable Conformance
 extension Float: ConvertibleNumberType { public var doubleValue: Double { return Double(self) }}
 /// Double Representable Conformance

--- a/Sources/Prometheus/Utils.swift
+++ b/Sources/Prometheus/Utils.swift
@@ -72,8 +72,6 @@ public extension ConvertibleNumberType {
     var floatValue: Float { return Float(doubleValue) }
     /// Number as an Int
     var intValue: Int { return lrint(doubleValue) }
-    /// Number as a CGFloat
-    var CGFloatValue: CGFloat { return CGFloat(doubleValue) }
 }
 
 /// Double Representable Conformance


### PR DESCRIPTION
Hey @MrLotU, thanks in advance for considering this PR. It would help us in some use cases we'd like to use this library 👍 

### Motivation and Context

In some environments it is better to avoid pulling in "dependencies" if we don't really use them. 
There can be situations in which CoreGraphics is not available yet one would still like to use this library.

The conformance is not super crucial to ship with SwiftPrometheus, if someone wants to they can conform GCFloat to `ConvertibleNumberType` manually.

### Description

Remote the not strictly necessary CoreGraphics usage.
