### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ By default, this should be accessible on your main serving port, at the `/metric
 ```swift
 app.get("metrics") { req -> EventLoopFuture<String> in
     let promise = req.eventLoop.makePromise(of: String.self)
-    try MetricsSystem.prometheus().collect(into: promise)
+    DispatchQueue.global().async {
+        do {
+            try MetricsSystem.prometheus().collect(into: promise)
+        } catch {
+            promise.fail(error)
+        }
+    }
     return promise.futureResult
 }
 ```


### PR DESCRIPTION
The Vapor 4 metrics endpoint example leads to a leaked promise error when running it in debug mode. Consider the following instead. 