### PR TITLE
fix Buckets helpers to not throw fatal error

### DIFF
--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -42,7 +42,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
         var arr = [Double]()
         var s = start
         for x in 0..<count {
-            arr[x] = s
+            arr.append(s)
             s += width
         }
         return Buckets(arr)
@@ -61,7 +61,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
         var arr = [Double]()
         var s = start
         for x in 0..<count {
-            arr[x] = s
+            arr.append(s)
             s *= factor
         }
         return Buckets(arr)

--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -39,12 +39,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
     ///     - count: Amount of buckets to generate, should be larger than zero. The +Inf bucket is not included in this count.
     public static func linear(start: Double, width: Double, count: Int) -> Buckets {
         assert(count >= 1, "Bucket.linear needs a count larger than 1")
-        var arr = [Double]()
-        var s = start
-        for _ in 0..<count {
-            arr.append(s)
-            s += width
-        }
+        let arr = (0..<count).map { Double(start) + Double($0) * Double(width) }
         return Buckets(arr)
     }
     

--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -41,7 +41,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
         assert(count >= 1, "Bucket.linear needs a count larger than 1")
         var arr = [Double]()
         var s = start
-        for x in 0..<count {
+        for _ in 0..<count {
             arr.append(s)
             s += width
         }
@@ -60,7 +60,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
         assert(factor > 1, "Bucket.exponential needs a factor larger than 1")
         var arr = [Double]()
         var s = start
-        for x in 0..<count {
+        for _ in 0..<count {
             arr.append(s)
             s *= factor
         }

--- a/Tests/SwiftPrometheusTests/BucketsTests.swift
+++ b/Tests/SwiftPrometheusTests/BucketsTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Prometheus
+class BucketsTests: XCTestCase {
+    func testExponentialDoesNotThrow() {
+        let buckets = Buckets.exponential(start: 1, factor: 2, count: 4)
+        XCTAssertEqual([1.0, 2.0, 4.0, 8.0, Double.greatestFiniteMagnitude], buckets.buckets)
+    }
+
+    func testLinearDoesNotThrow() {
+        let buckets = Buckets.linear(start: 1, width: 20, count: 4)
+        XCTAssertEqual([1, 21, 41, 61, Double.greatestFiniteMagnitude], buckets.buckets)
+    }
+}


### PR DESCRIPTION
Hi @MrLotU. Thanks for considering this PR.
In my project I needed to create custom buckets and stumbled upon `Buckets` helpers throwing fatal errors all the time. Here's a fix for this.

### Checklist
- [+] The provided tests still run.
- [+] I've created new tests where needed.
- [+] I've updated the documentation if necessary.

### Motivation and Context

Buckets static helpers are always throwing fatal errors.

### Description

`Buckets` static helpers are working now.