### PR TITLE
make labels classes public to allow users to create their own prometh…

### DIFF
--- a/Sources/Prometheus/PrometheusMetrics.swift
+++ b/Sources/Prometheus/PrometheusMetrics.swift
@@ -236,25 +236,25 @@ private struct StringCodingKey: CodingKey {
 
 
 /// Helper for dimensions
-private struct DimensionLabels: MetricLabels {
+public struct DimensionLabels: MetricLabels {
     let dimensions: [(String, String)]
     
-    init() {
+    public init() {
         self.dimensions = []
     }
     
-    init(_ dimensions: [(String, String)]) {
+    public init(_ dimensions: [(String, String)]) {
         self.dimensions = dimensions
     }
     
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringCodingKey.self)
         try self.dimensions.forEach {
             try container.encode($0.1, forKey: .init($0.0))
         }
     }
     
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(dimensions.map { "\($0.0)-\($0.1)"})
     }
     
@@ -262,31 +262,33 @@ private struct DimensionLabels: MetricLabels {
         return dimensions.map { $0.0 }.joined(separator: "-")
     }
     
-    static func == (lhs: DimensionLabels, rhs: DimensionLabels) -> Bool {
+    public static func == (lhs: DimensionLabels, rhs: DimensionLabels) -> Bool {
         return lhs.dimensions.map { "\($0.0)-\($0.1)"} == rhs.dimensions.map { "\($0.0)-\($0.1)"}
     }
 }
 
 /// Helper for dimensions
-private struct DimensionHistogramLabels: HistogramLabels {
+/// swift-metrics api doesn't allow setting buckets explicitly.
+/// If default buckets don't fit, this Labels implementation is a nice default to create Prometheus metric types wtih
+public struct DimensionHistogramLabels: HistogramLabels {
     /// Bucket
-    var le: String
+    public var le: String
     /// Dimensions
     let dimensions: [(String, String)]
     
     /// Empty init
-    init() {
+    public init() {
         self.le = ""
         self.dimensions = []
     }
     
     /// Init with dimensions
-    init(_ dimensions: [(String, String)]) {
+    public init(_ dimensions: [(String, String)]) {
         self.le = ""
         self.dimensions = dimensions
     }
     
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringCodingKey.self)
         try self.dimensions.forEach {
             try container.encode($0.1, forKey: .init($0.0))
@@ -294,7 +296,7 @@ private struct DimensionHistogramLabels: HistogramLabels {
         try container.encode(le, forKey: .init("le"))
     }
     
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(dimensions.map { "\($0.0)-\($0.1)"})
         hasher.combine(le)
     }
@@ -303,31 +305,31 @@ private struct DimensionHistogramLabels: HistogramLabels {
         return dimensions.map { $0.0 }.joined(separator: "-")
     }
     
-    static func == (lhs: DimensionHistogramLabels, rhs: DimensionHistogramLabels) -> Bool {
+    public static func == (lhs: DimensionHistogramLabels, rhs: DimensionHistogramLabels) -> Bool {
         return lhs.dimensions.map { "\($0.0)-\($0.1)"} == rhs.dimensions.map { "\($0.0)-\($0.1)"} && rhs.le == lhs.le
     }
 }
 
 /// Helper for dimensions
-private struct DimensionSummaryLabels: SummaryLabels {
+public struct DimensionSummaryLabels: SummaryLabels {
     /// Quantile
-    var quantile: String
+    public var quantile: String
     /// Dimensions
     let dimensions: [(String, String)]
     
     /// Empty init
-    init() {
+    public init() {
         self.quantile = ""
         self.dimensions = []
     }
     
     /// Init with dimensions
-    init(_ dimensions: [(String, String)]) {
+    public init(_ dimensions: [(String, String)]) {
         self.quantile = ""
         self.dimensions = dimensions
     }
     
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringCodingKey.self)
         try self.dimensions.forEach {
             try container.encode($0.1, forKey: .init($0.0))
@@ -335,7 +337,7 @@ private struct DimensionSummaryLabels: SummaryLabels {
         try container.encode(quantile, forKey: .init("quantile"))
     }
     
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(dimensions.map { "\($0.0)-\($0.1)"})
         hasher.combine(quantile)
     }
@@ -344,7 +346,7 @@ private struct DimensionSummaryLabels: SummaryLabels {
         return dimensions.map { $0.0 }.joined(separator: "-")
     }
     
-    static func == (lhs: DimensionSummaryLabels, rhs: DimensionSummaryLabels) -> Bool {
+    public static func == (lhs: DimensionSummaryLabels, rhs: DimensionSummaryLabels) -> Bool {
         return lhs.dimensions.map { "\($0.0)-\($0.1)"} == rhs.dimensions.map { "\($0.0)-\($0.1)"} && rhs.quantile == lhs.quantile
     }
 }


### PR DESCRIPTION
…eus classes

Hi, @MrLotU. Thanks for considering this PR. When adopting SwiftPrometheus in my project, I had to use custom buckets. Current `swift-metrics` don't allow setting buckets directly, so I had to use `Prometheus.createHistogram` directly. Unfortunately, default labels implementation for `createHistogram` is `EmptyHistogramLabels`, and I can't pass `DimensionalHistogramLables` explicitly because they're private to the library. I think making them public will result in better flexibility and allow adopters to enable more use cases and simplify building their own logic on top current SwiftPrometheus.

DimensionLabels, DimensionHistogramLabels, DimensionSummaryLabels are made public

### Checklist
- [+] The provided tests still run.
- [n/a] I've created new tests where needed.
- [+] I've updated the documentation if necessary.

### Motivation and Context
swift-metrics api does not allow setting buckets explicitly. This forces adopter either use SwiftPrometheus classes directly or only use default buckets. When default buckets don't fit and direct Prometheus classes are used, using direct Prometheus classes for other types of metrics can be logical and may lead to a more standardised readable code.

### Description
Private labels classes forces library adopter to copy/paste labels classes when they want to use Histograms with SwiftPrometheus metrics types directly. Having them public may simplify the adoption.
