### PR TITLE
Histogram backed timer

### DIFF
--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -16,15 +16,10 @@ public class PrometheusClient {
     /// Lock used for thread safety
     private let lock: Lock
     
-    /// Sanitizers used to clean up label values provided through
-    /// swift-metrics.
-    public let sanitizer: LabelSanitizer
-    
     /// Create a PrometheusClient instance
-    public init(labelSanitizer sanitizer: LabelSanitizer = PrometheusLabelSanitizer()) {
+    public init() {
         self.metrics = []
         self.metricTypeMap = [:]
-        self.sanitizer = sanitizer
         self.lock = Lock()
     }
     

--- a/Sources/Prometheus/PrometheusMetricsConfiguration.swift
+++ b/Sources/Prometheus/PrometheusMetricsConfiguration.swift
@@ -1,19 +1,45 @@
-public struct PrometheusMetricsConfiguration {
-    /// Sanitizers used to clean up label values provided through
-    /// swift-metrics.
-    public var labelSanitizer: LabelSanitizer
+extension PrometheusMetricsFactory {
 
-    /// This parameter will define what implementation will be used for bridging `swift-metrics` to Prometheus types.
-    public var timerImplementation: PrometheusTimerImplementation
+    public struct TimerImplementation {
+        enum _Wrapped {
+            case summary(defaultQuantiles: [Double])
+            case histogram(defaultBuckets: Buckets)
+        }
 
-    /// Default buckets for `Recorder` with aggregation.
-    public var defaultHistogramBuckets: Buckets
+        var _wrapped: _Wrapped
 
-    public init(labelSanitizer: LabelSanitizer = PrometheusLabelSanitizer(),
-                timerImplementation: PrometheusTimerImplementation = .summary(),
-                defaultHistogramBuckets: Buckets = .defaultBuckets) {
-        self.labelSanitizer = labelSanitizer
-        self.timerImplementation = timerImplementation
-        self.defaultHistogramBuckets = defaultHistogramBuckets
+        private init(_ wrapped: _Wrapped) {
+            self._wrapped = wrapped
+        }
+
+        public static func summary(defaultQuantiles: [Double] = Prometheus.defaultQuantiles) -> TimerImplementation {
+            TimerImplementation(.summary(defaultQuantiles: defaultQuantiles))
+        }
+
+        public static func histogram(defaultBuckets: Buckets = Buckets.defaultBuckets) -> TimerImplementation {
+            TimerImplementation(.histogram(defaultBuckets: defaultBuckets))
+        }
+    }
+
+
+    /// Configuration for PrometheusClient to swift-metrics api bridge.
+    public struct Configuration {
+        /// Sanitizers used to clean up label values provided through
+        /// swift-metrics.
+        public var labelSanitizer: LabelSanitizer
+
+        /// This parameter will define what implementation will be used for bridging `swift-metrics` to Prometheus types.
+        public var timerImplementation: PrometheusMetricsFactory.TimerImplementation
+
+        /// Default buckets for `Recorder` with aggregation.
+        public var defaultHistogramBuckets: Buckets
+
+        public init(labelSanitizer: LabelSanitizer = PrometheusLabelSanitizer(),
+                    timerImplementation: PrometheusMetricsFactory.TimerImplementation = .summary(),
+                    defaultHistogramBuckets: Buckets = .defaultBuckets) {
+            self.labelSanitizer = labelSanitizer
+            self.timerImplementation = timerImplementation
+            self.defaultHistogramBuckets = defaultHistogramBuckets
+        }
     }
 }

--- a/Sources/Prometheus/PrometheusMetricsConfiguration.swift
+++ b/Sources/Prometheus/PrometheusMetricsConfiguration.swift
@@ -13,11 +13,11 @@ extension PrometheusMetricsFactory {
         }
 
         public static func summary(defaultQuantiles: [Double] = Prometheus.defaultQuantiles) -> TimerImplementation {
-            TimerImplementation(.summary(defaultQuantiles: defaultQuantiles))
+            return TimerImplementation(.summary(defaultQuantiles: defaultQuantiles))
         }
 
         public static func histogram(defaultBuckets: Buckets = Buckets.defaultBuckets) -> TimerImplementation {
-            TimerImplementation(.histogram(defaultBuckets: defaultBuckets))
+            return TimerImplementation(.histogram(defaultBuckets: defaultBuckets))
         }
     }
 
@@ -32,14 +32,14 @@ extension PrometheusMetricsFactory {
         public var timerImplementation: PrometheusMetricsFactory.TimerImplementation
 
         /// Default buckets for `Recorder` with aggregation.
-        public var defaultHistogramBuckets: Buckets
+        public var defaultRecorderBuckets: Buckets
 
         public init(labelSanitizer: LabelSanitizer = PrometheusLabelSanitizer(),
                     timerImplementation: PrometheusMetricsFactory.TimerImplementation = .summary(),
-                    defaultHistogramBuckets: Buckets = .defaultBuckets) {
+                    defaultRecorderBuckets: Buckets = .defaultBuckets) {
             self.labelSanitizer = labelSanitizer
             self.timerImplementation = timerImplementation
-            self.defaultHistogramBuckets = defaultHistogramBuckets
+            self.defaultRecorderBuckets = defaultRecorderBuckets
         }
     }
 }

--- a/Sources/Prometheus/PrometheusMetricsConfiguration.swift
+++ b/Sources/Prometheus/PrometheusMetricsConfiguration.swift
@@ -1,0 +1,19 @@
+public struct PrometheusMetricsConfiguration {
+    /// Sanitizers used to clean up label values provided through
+    /// swift-metrics.
+    public var labelSanitizer: LabelSanitizer
+
+    /// This parameter will define what implementation will be used for bridging `swift-metrics` to Prometheus types.
+    public var timerImplementation: PrometheusTimerImplementation
+
+    /// Default buckets for `Recorder` with aggregation.
+    public var defaultHistogramBuckets: Buckets
+
+    public init(labelSanitizer: LabelSanitizer = PrometheusLabelSanitizer(),
+                timerImplementation: PrometheusTimerImplementation = .summary(),
+                defaultHistogramBuckets: Buckets = .defaultBuckets) {
+        self.labelSanitizer = labelSanitizer
+        self.timerImplementation = timerImplementation
+        self.defaultHistogramBuckets = defaultHistogramBuckets
+    }
+}

--- a/Sources/PrometheusExample/main.swift
+++ b/Sources/PrometheusExample/main.swift
@@ -4,7 +4,7 @@ import NIO
 
 let myProm = PrometheusClient()
 
-MetricsSystem.bootstrap(myProm)
+MetricsSystem.bootstrap(PrometheusMetricsFactory(prometheusClient: myProm))
 
 for _ in 0...Int.random(in: 10...100) {
     let c = Counter(label: "test")

--- a/Sources/PrometheusExample/main.swift
+++ b/Sources/PrometheusExample/main.swift
@@ -4,7 +4,7 @@ import NIO
 
 let myProm = PrometheusClient()
 
-MetricsSystem.bootstrap(PrometheusMetricsFactory(prometheusClient: myProm))
+MetricsSystem.bootstrap(PrometheusMetricsFactory(client: myProm))
 
 for _ in 0...Int.random(in: 10...100) {
     let c = Counter(label: "test")

--- a/Tests/SwiftPrometheusTests/GaugeTests.swift
+++ b/Tests/SwiftPrometheusTests/GaugeTests.swift
@@ -25,7 +25,7 @@ final class GaugeTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(prom)
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
     }
     
     override func tearDown() {

--- a/Tests/SwiftPrometheusTests/GaugeTests.swift
+++ b/Tests/SwiftPrometheusTests/GaugeTests.swift
@@ -25,7 +25,7 @@ final class GaugeTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: prom))
     }
     
     override func tearDown() {

--- a/Tests/SwiftPrometheusTests/HistogramTests.swift
+++ b/Tests/SwiftPrometheusTests/HistogramTests.swift
@@ -26,7 +26,7 @@ final class HistogramTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: prom))
     }
     
     override func tearDown() {

--- a/Tests/SwiftPrometheusTests/HistogramTests.swift
+++ b/Tests/SwiftPrometheusTests/HistogramTests.swift
@@ -26,7 +26,7 @@ final class HistogramTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(prom)
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
     }
     
     override func tearDown() {

--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -14,7 +14,7 @@ final class PrometheusMetricsTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(prom)
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
     }
     
     override func tearDown() {
@@ -144,5 +144,67 @@ final class PrometheusMetricsTests: XCTestCase {
             # TYPE my_gauge gauge
             my_gauge 100.0\n
             """)
+    }
+
+    func testHistogramBackedTimer() {
+        let prom = PrometheusClient()
+        var config = PrometheusMetricsConfiguration()
+        config.timerImplementation = .histogram()
+        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        metricsFactory.makeTimer(label: "duration_nanos", dimensions: []).recordNanoseconds(1)
+        guard let histogram: PromHistogram<Int64, DimensionHistogramLabels> = prom.getMetricInstance(with: "duration_nanos", andType: .histogram) else {
+            XCTFail("Timer should be backed by Histogram")
+            return
+        }
+        let result = histogram.collect()
+        let buckets = result.split(separator: "\n").filter { $0.contains("duration_nanos_bucket") }
+        // we should have 64 buckets for histogram without labels
+        XCTAssertFalse(buckets.isEmpty, "default histogram backed timer buckets")
+    }
+
+    func testHistogramBackedTimer_scaleFromNanoseconds() {
+        let prom = PrometheusClient()
+        var config = PrometheusMetricsConfiguration()
+        config.timerImplementation = .histogram()
+        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
+        timer.preferDisplayUnit(.microseconds)
+        timer.recordNanoseconds(1)
+        guard let histogram: PromHistogram<Int64, DimensionHistogramLabels> = prom.getMetricInstance(with: "duration_nanos", andType: .histogram) else {
+            XCTFail("Timer should be backed by Histogram")
+            return
+        }
+        let result = histogram.collect()
+        let buckets = result.split(separator: "\n").filter { $0.contains("duration_nanos_bucket") }
+        // we should have 64 buckets for histogram without labels
+        XCTAssertFalse(buckets.isEmpty, "default histogram backed timer buckets")
+
+        result.split(separator: "\n").filter { $0.contains("duration_nanos_bucket") }.forEach {
+            // every bucket getting the value would mean that incoming value of 1000 nanos was scaled to 1 microsecond
+            XCTAssertTrue($0.hasSuffix(" 1"))
+        }
+    }
+
+    func testDestroyHistogramTimer() {
+        let prom = PrometheusClient()
+        var config = PrometheusMetricsConfiguration()
+        config.timerImplementation = .histogram()
+        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
+        timer.recordNanoseconds(1)
+        metricsFactory.destroyTimer(timer)
+        let histogram: PromHistogram<Int64, DimensionHistogramLabels>? = prom.getMetricInstance(with: "duration_nanos", andType: .histogram)
+        XCTAssertNil(histogram)
+    }
+    func testDestroySummaryTimer() {
+        let prom = PrometheusClient()
+        var config = PrometheusMetricsConfiguration()
+        config.timerImplementation = .summary()
+        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom)
+        let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
+        timer.recordNanoseconds(1)
+        metricsFactory.destroyTimer(timer)
+        let summary: PromSummary<Int64, DimensionSummaryLabels>? = prom.getMetricInstance(with: "duration_nanos", andType: .summary)
+        XCTAssertNil(summary)
     }
 }

--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -148,7 +148,7 @@ final class PrometheusMetricsTests: XCTestCase {
 
     func testHistogramBackedTimer() {
         let prom = PrometheusClient()
-        var config = PrometheusMetricsConfiguration()
+        var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
         let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
         metricsFactory.makeTimer(label: "duration_nanos", dimensions: []).recordNanoseconds(1)
@@ -164,7 +164,7 @@ final class PrometheusMetricsTests: XCTestCase {
 
     func testHistogramBackedTimer_scaleFromNanoseconds() {
         let prom = PrometheusClient()
-        var config = PrometheusMetricsConfiguration()
+        var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
         let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
@@ -187,7 +187,7 @@ final class PrometheusMetricsTests: XCTestCase {
 
     func testDestroyHistogramTimer() {
         let prom = PrometheusClient()
-        var config = PrometheusMetricsConfiguration()
+        var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
         let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
@@ -198,7 +198,7 @@ final class PrometheusMetricsTests: XCTestCase {
     }
     func testDestroySummaryTimer() {
         let prom = PrometheusClient()
-        var config = PrometheusMetricsConfiguration()
+        var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .summary()
         let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])

--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -14,7 +14,7 @@ final class PrometheusMetricsTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: prom))
     }
     
     override func tearDown() {
@@ -150,7 +150,7 @@ final class PrometheusMetricsTests: XCTestCase {
         let prom = PrometheusClient()
         var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
-        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        let metricsFactory = PrometheusMetricsFactory(client: prom, configuration: config)
         metricsFactory.makeTimer(label: "duration_nanos", dimensions: []).recordNanoseconds(1)
         guard let histogram: PromHistogram<Int64, DimensionHistogramLabels> = prom.getMetricInstance(with: "duration_nanos", andType: .histogram) else {
             XCTFail("Timer should be backed by Histogram")
@@ -166,7 +166,7 @@ final class PrometheusMetricsTests: XCTestCase {
         let prom = PrometheusClient()
         var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
-        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        let metricsFactory = PrometheusMetricsFactory(client: prom, configuration: config)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
         timer.preferDisplayUnit(.microseconds)
         timer.recordNanoseconds(1)
@@ -189,7 +189,7 @@ final class PrometheusMetricsTests: XCTestCase {
         let prom = PrometheusClient()
         var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .histogram()
-        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom, configuration: config)
+        let metricsFactory = PrometheusMetricsFactory(client: prom, configuration: config)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
         timer.recordNanoseconds(1)
         metricsFactory.destroyTimer(timer)
@@ -200,7 +200,7 @@ final class PrometheusMetricsTests: XCTestCase {
         let prom = PrometheusClient()
         var config = PrometheusMetricsFactory.Configuration()
         config.timerImplementation = .summary()
-        let metricsFactory = PrometheusMetricsFactory(prometheusClient: prom)
+        let metricsFactory = PrometheusMetricsFactory(client: prom)
         let timer = metricsFactory.makeTimer(label: "duration_nanos", dimensions: [])
         timer.recordNanoseconds(1)
         metricsFactory.destroyTimer(timer)

--- a/Tests/SwiftPrometheusTests/SanitizerTests.swift
+++ b/Tests/SwiftPrometheusTests/SanitizerTests.swift
@@ -38,7 +38,7 @@ final class SanitizerTests: XCTestCase {
     
     func testIntegratedSanitizer() throws {
         let prom = PrometheusClient()
-        MetricsSystem.bootstrapInternal(prom)
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
         
         CoreMetrics.Counter(label: "Test.Counter").increment(by: 10)
         

--- a/Tests/SwiftPrometheusTests/SanitizerTests.swift
+++ b/Tests/SwiftPrometheusTests/SanitizerTests.swift
@@ -38,7 +38,7 @@ final class SanitizerTests: XCTestCase {
     
     func testIntegratedSanitizer() throws {
         let prom = PrometheusClient()
-        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: prom))
         
         CoreMetrics.Counter(label: "Test.Counter").increment(by: 10)
         

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -26,7 +26,7 @@ final class SummaryTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: prom))
     }
     
     override func tearDown() {

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -26,7 +26,7 @@ final class SummaryTests: XCTestCase {
     override func setUp() {
         self.prom = PrometheusClient()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        MetricsSystem.bootstrapInternal(prom)
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(prometheusClient: prom))
     }
     
     override func tearDown() {


### PR DESCRIPTION
Hey @MrLotU,

Thanks for considering this PR. In my project I'm running multiple replicas of my backend service. For a proper monitoring I needed aggregatable timer metrics to get cumulative percentiles across the whole fleet. Here's the solution I came up with. Since the project is in `alpha`, I decided to start with breaking a few APIs in order to keep the code simple. Please let me know if you think we should approach this differently.

Fixes https://github.com/MrLotU/SwiftPrometheus/issues/44

### Checklist
- [+] The provided tests still run.
- [+] I've created new tests where needed.
- [+] I've updated the documentation if necessary.

### Motivation and Context
Server side applications are never run in as single instance. Summary backed timer doesn't allow aggregation and therefore doesn't allow to render accumulated latency percentiles across multiple instances. Histogram backed timer provides a solution with it.
Timer implementation is yet another fact that only makes sense for bridging `Prometheus` to `swift-metrics` (in addition to `Labels` that are init parameters in `swift-metrics` world and call parameters in `Prometheus` world, and therefore `LabelSanitizer`). It feels natural to separate non-trivial `swift-metrics` bridge from Prometheus core, keeping either of them simpler and more testable. 

### Description
- MetricsFactory conformance is now a wrapper around PrometheusClient. This allows us to be much more flexible and configurable when bridging `swift-metrics` api to Prometheus backend (i.e. picking a Timer implementation, setting default quantiles/buckets, in future potentially setting base labels).
- Introduced configuration object.
- Introduced `Histogram` backed `Timer` implementation.