### PR TITLE
Add fix and test for MetricsSystem.prometheus()

### DIFF
--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -21,6 +21,13 @@ final class PrometheusMetricsTests: XCTestCase {
         self.prom = nil
         try! self.group.syncShutdownGracefully()
     }
+
+    func testGetPrometheus() {
+        MetricsSystem.bootstrapInternal(NOOPMetricsHandler.instance)
+        XCTAssertThrowsError(try MetricsSystem.prometheus())
+        MetricsSystem.bootstrapInternal(PrometheusMetricsFactory(client: self.prom))
+        XCTAssertNoThrow(try MetricsSystem.prometheus())
+    }
     
     func testCounter() {
         let counter = Counter(label: "my_counter")


### PR DESCRIPTION
Fixes #48 

SwiftPrometheus 1.0.0 Alpha 10 introduced a bug where `MetricsSystem.prometheus()` would no longer work, since it looks for a `PrometheusClient` instance, but since Alpha 10 it's a wrapper struct.

Introduced new with this PR is a `PrometheusWrappedMetricsFactory` protocol that should be used by any `MetricsFactory` wrapping `PrometheusClient` in any way.

`MetricsSystem.prometheus()` will now look for a `PrometheusWrappedMetricsFactory` and return the underlying `client`

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.