### PR TITLE
Update minimum required Swift version to 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 
 import PackageDescription
 
@@ -19,12 +19,19 @@ let package = Package(
     targets: [
         .target(
             name: "Prometheus",
-            dependencies: ["CoreMetrics", "NIOConcurrencyHelpers", "NIO"]),
+            dependencies: [
+                .product(name: "CoreMetrics", package: "swift-metrics"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIO", package: "swift-nio"),
+            ]),
         .target(
             name: "PrometheusExample",
-            dependencies: ["Prometheus", "Metrics"]),
+            dependencies: [
+                .target(name: "Prometheus"),
+                .product(name: "Metrics", package: "swift-metrics"),
+            ]),
         .testTarget(
             name: "SwiftPrometheusTests",
-            dependencies: ["Prometheus"]),
+            dependencies: [.target(name: "Prometheus")]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/MrLotU/SwiftPrometheus.svg?style=svg)](https://circleci.com/gh/MrLotU/SwiftPrometheus)[![Swift 5.0](https://img.shields.io/badge/swift-5.0-orange.svg?style=flat)](http://swift.org)
+[![CircleCI](https://circleci.com/gh/MrLotU/SwiftPrometheus.svg?style=svg)](https://circleci.com/gh/MrLotU/SwiftPrometheus)[![Swift 5.2](https://img.shields.io/badge/swift-5.2-orange.svg?style=flat)](http://swift.org)
 
 # SwiftPrometheus, Prometheus client for Swift
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   swift5:
     docker:
-      - image: swift:5.0
+      - image: swift:5.2
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
@@ -11,7 +11,7 @@ jobs:
       - run: swift test
   bionic:
     docker:
-      - image: vapor/swift:5.1-bionic
+      - image: vapor/swift:5.2-bionic
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
@@ -19,7 +19,7 @@ jobs:
       - run: swift test
   bionic-release:
     docker:
-      - image: vapor/swift:5.1-bionic
+      - image: vapor/swift:5.2-bionic
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev


### PR DESCRIPTION
### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

Motivation:

- SwiftNIO will soon raise it's minimum supported version of Swift from
  5.0 to 5.2 (see: https://github.com/apple/swift-nio/pull/1860)
- Swift 5.0 and 5.1 users will not be able to use future versions of NIO
  (most likely from version 2.30.0).
- Since Prometheus depends on NIO and NIO is so pervasive in the
  ecosystem it makes sense to follow NIOs lead in terms of supported
  Swift versions.

Modifications:

- Update Package.swift to change the tools version to 5.2
- Use the newer syntax for specifying target dependencies
- Remove Package.resolved since it has little value for libraries
- Update circle.yml to update CI jobs
- Update Swift version badge in README.md