### PR TITLE
Add floating point counter

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "swift-metrics",
-        "repositoryURL": "https://github.com/rauhul/swift-metrics.git",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
-          "branch": "feature/floating-point-counter",
-          "revision": "7f85b16b9791154162beea7c670dd3cd2d3efd17",
-          "version": null
+          "branch": null,
+          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "repositoryURL": "https://github.com/rauhul/swift-metrics.git",
         "state": {
-          "branch": null,
-          "revision": "708b960b4605abb20bc55d65abf6bad607252200",
-          "version": "2.0.0"
+          "branch": "feature/floating-point-counter",
+          "revision": "7f85b16b9791154162beea7c670dd3cd2d3efd17",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["PrometheusExample"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/rauhul/swift-metrics.git", .branch("feature/floating-point-counter")),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.2.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["PrometheusExample"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
+        .package(url: "https://github.com/rauhul/swift-metrics.git", .branch("feature/floating-point-counter")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [

--- a/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
+++ b/Tests/SwiftPrometheusTests/PrometheusMetricsTests.swift
@@ -45,6 +45,22 @@ final class PrometheusMetricsTests: XCTestCase {
         """)
     }
 
+    func testFloatingPointCounter() {
+        let counter = FloatingPointCounter(label: "my_fp_counter")
+        counter.increment(by: 3.5)
+        let counterTwo = FloatingPointCounter(label: "my_fp_counter", dimensions: [("myValue", "labels")])
+        counterTwo.increment(by: 10.4)
+
+        let promise = self.eventLoop.makePromise(of: String.self)
+        prom.collect(promise.succeed)
+
+        XCTAssertEqual(try! promise.futureResult.wait(), """
+        # TYPE my_fp_counter counter
+        my_fp_counter 3.5
+        my_fp_counter{myValue=\"labels\"} 10.4\n
+        """)
+    }
+
     func testMetricDestroying() {
         let counter = Counter(label: "my_counter")
         counter.increment()


### PR DESCRIPTION
Adds support for swift-metrics `FloatingPointCounter` (https://github.com/apple/swift-metrics/pull/99)

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

### Description
Adds a new `MetricsFloatingPointCounter` type that uses a `PromCounter<Double, DimensionLabels>` under the hood, allowing for `Double` values to be stored.