### PR TITLE
Finer concurrency in 'MetricType.observe' / 'MetricType.collect'

### DIFF
--- a/Sources/Prometheus/MetricTypes/Counter.swift
+++ b/Sources/Prometheus/MetricTypes/Counter.swift
@@ -48,23 +48,24 @@ public class PromCounter<NumType: Numeric, Labels: MetricLabels>: PromMetric, Pr
     /// - Returns:
     ///     Newline separated Prometheus formatted metric string
     public func collect() -> String {
-        return self.lock.withLock {
-            var output = [String]()
-            
-            if let help = self.help {
-                output.append("# HELP \(self.name) \(help)")
-            }
-            output.append("# TYPE \(self.name) \(self._type)")
-            
-            output.append("\(self.name) \(self.value)")
-            
-            self.metrics.forEach { (labels, value) in
-                let labelsString = encodeLabels(labels)
-                output.append("\(self.name)\(labelsString) \(value)")
-            }
-            
-            return output.joined(separator: "\n")
+        let (value, metrics) = self.lock.withLock {
+            (self.value, self.metrics)
         }
+        var output = [String]()
+
+        if let help = self.help {
+            output.append("# HELP \(self.name) \(help)")
+        }
+        output.append("# TYPE \(self.name) \(self._type)")
+
+        output.append("\(self.name) \(value)")
+
+        metrics.forEach { (labels, value) in
+            let labelsString = encodeLabels(labels)
+            output.append("\(self.name)\(labelsString) \(value)")
+        }
+
+        return output.joined(separator: "\n")
     }
     
     /// Increments the Counter
@@ -104,4 +105,3 @@ public class PromCounter<NumType: Numeric, Labels: MetricLabels>: PromMetric, Pr
         }
     }
 }
-

--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -290,4 +290,3 @@ public enum PrometheusError: Error {
     /// but there was no `PrometheusClient` bootstrapped
     case prometheusFactoryNotBootstrapped(bootstrappedWith: String)
 }
-


### PR DESCRIPTION
Every metric type has a lock that's taken for the whole duration of consuming a metric value, and also for the whole duration of observe. This PR puts as much computations out of critical section as we can afford, which results in a significant performance boost.
With these changes, `Lock.withLock` takes only 25% of `PromHistogram.observe`, of which half is locking/unlocking and the other half is `collection.filter`.
Reducing the scope of locking helps bringing `lock.withLock` to 50% of `PromHistogram.observe`. Changing `subHistograms` from array to map, reduces it further to `25%`

### Checklist
- [ + ] The provided tests still run.
- [ N/A ] I've created new tests where needed.
- [ N/A ] I've updated the documentation if necessary.

### Motivation and Context
This PR brings concurrency optimisations that result in better emission latencies.

### Description
Every MetricType's lock is now only held during access to corresponding state in a thread safe manner, all computations are moved outside critical section.
subHistograms is now a `Map` instead of array.
