### PR TITLE
move labels equality check out of critical section in summary/histogram

### DIFF
--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -195,19 +195,31 @@ public class PromSummary<NumType: DoubleRepresentable, Labels: SummaryLabels>: P
     fileprivate func getOrCreateSummary(withLabels labels: Labels) -> PromSummary<NumType, Labels> {
         let subSummaries = self.lock.withLock { self.subSummaries }
         if let summary = subSummaries[labels] {
-            if summary.name == self.name, summary.help == self.help {
-                return summary
-            } else {
-                fatalError("Somehow got 2 summaries with the same data type")
-            }
+            precondition(summary.name == self.name,
+                         """
+                         Somehow got 2 subSummaries with the same data type  / labels 
+                         but different names: expected \(self.name), got \(summary.name)
+                         """)
+            precondition(summary.help == self.help,
+                         """
+                         Somehow got 2 subSummaries with the same data type  / labels 
+                         but different help messages: expected \(self.help ?? "nil"), got \(summary.help ?? "nil")
+                         """)
+            return summary
         } else {
             return lock.withLock {
                 if let summary = self.subSummaries[labels] {
-                    if summary.name == self.name, summary.help == self.help {
-                        return summary
-                    } else {
-                        fatalError("Somehow got 2 summaries with the same data type")
-                    }
+                    precondition(summary.name == self.name,
+                                 """
+                                 Somehow got 2 subSummaries with the same data type  / labels 
+                                 but different names: expected \(self.name), got \(summary.name)
+                                 """)
+                    precondition(summary.help == self.help,
+                                 """
+                                 Somehow got 2 subSummaries with the same data type  / labels 
+                                 but different help messages: expected \(self.help ?? "nil"), got \(summary.help ?? "nil")
+                                 """)
+                    return summary
                 }
                 guard let prometheus = prometheus else {
                     fatalError("Lingering Summary")

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -70,6 +70,39 @@ final class SummaryTests: XCTestCase {
         my_summary_sum{myValue="labels"} 123.0\n
         """)
     }
+
+    func testConcurrent() throws {
+        let prom = PrometheusClient()
+        let summary = prom.createSummary(forType: Double.self, named: "my_summary",
+                                             helpText: "Summary for testing",
+                                             labels: DimensionSummaryLabels.self)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 8)
+        let semaphore = DispatchSemaphore(value: 2)
+        _ = elg.next().submit {
+            for _ in 1...1_000 {
+                let labels = DimensionSummaryLabels([("myValue", "1")])
+                let labels2 = DimensionSummaryLabels([("myValue", "2")])
+
+                summary.observe(1.0, labels)
+                summary.observe(1.0, labels2)
+            }
+            semaphore.signal()
+        }
+        _ = elg.next().submit {
+            for _ in 1...1_000 {
+                let labels = DimensionSummaryLabels([("myValue", "1")])
+                let labels2 = DimensionSummaryLabels([("myValue", "2")])
+
+                summary.observe(1.0, labels2)
+                summary.observe(1.0, labels)
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        try elg.syncShutdownGracefully()
+        XCTAssertTrue(summary.collect().contains("my_summary_count 4000.0"))
+        XCTAssertTrue(summary.collect().contains("my_summary_sum 4000.0"))
+    }
     
     func testSummaryWithPreferredDisplayUnit() {
         let summary = Timer(label: "my_summary", preferredDisplayUnit: .seconds)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

This PR moves `Labels` equality check outside of `Lock`.
The rationale behind it is following:
App's metrics list is usually bound and don't grow a lot after some time of the app being operational. The code already has this constraint implicitly by the fact that none of `Prometheus.metrics`, `Histogram.subHistograms`, `Summary.subSummaries`, `Counter.metrics` are bounded, and will eventually cause an OOM if grow indefinitely. From the domain standpoint, unique label names and values are discouraged and don't provide a lot of insight to app's behaviour.
With the above constraint we know that after some time of app being operational, all or most of label key-value pairs are already stored in corresponding `Histogram.subHistograms` / `Summary.subSummaries`. This makes getting a subSummary/subHistogram from the map a target for optimisations: getOrCreate flow becomes highly skewed towards `get` part. Suggested change improves performance of `get` part of `getOrCreate` and increases the cost less frequently used `create` part. On my local machine this results in more than 2x throughput boost for the following test setups:
```swift

    func testConcurrent() throws {
        let prom = PrometheusClient()
        let histogram = prom.createHistogram(forType: Double.self, 
                                             named: "my_histogram",
                                             helpText: "Histogram for testing",
                                             buckets: Buckets.exponential(start: 1, factor: 2, count: 63),
                                             labels: DimensionHistogramLabels.self)
        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 8)
        let semaphore = DispatchSemaphore(value: 2)
        let time = DispatchTime.now()
        elg.next().submit {
            while DispatchTime.now().uptimeNanoseconds - time.uptimeNanoseconds < 10_000_000_000 {
                let labels = DimensionHistogramLabels([("myValue", "1")])
                histogram.observe(1.0, labels)
            }
            semaphore.signal()
        }
        elg.next().submit {
            while DispatchTime.now().uptimeNanoseconds - time.uptimeNanoseconds < 10_000_000_000 {
                let labels = DimensionHistogramLabels([("myValue", "2")])
                histogram.observe(1.0, labels)
            }
            semaphore.signal()
        }
        semaphore.wait()
        try elg.syncShutdownGracefully()
        print(histogram.collect())
        print(DispatchTime.now().uptimeNanoseconds - time.uptimeNanoseconds)
    }
```

### Checklist
- [ + ] The provided tests still run.
- [ + ] I've created new tests where needed.
- [ N/A ] I've updated the documentation if necessary.

### Motivation and Context
This PR optimises metric emission, which results in higher throughput and lower impact on running system.

### Description
scope of locking is now reduced to only obtain/modify current value of `PromHistogram.subHistograms` / `PromSummary.subSummaries`
If subHistogram/subSummaries for given labels is not yet added to the corresponding `PromHistogram` / `PromSummary`, the lock will be held twice: to get current value and to re-check + store new value.

- Created tests to access/update Summary/Histogram from multiple threads
- Ran TSAN against the change to check for concurrency issues.
