### PR TITLE
fix display unit

### DIFF
--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -139,7 +139,8 @@ public class PromSummary<NumType: DoubleRepresentable, Labels: SummaryLabels>: P
     
     // Updated for SwiftMetrics 2.0 to be unit agnostic if displayUnit is set or default to nanoseconds.
     private func format(_ v: Double) -> Double {
-        let displayUnitScale = self.displayUnit?.scaleFromNanoseconds ?? 1
+        let displayUnit = lock.withLock { self.displayUnit }
+        let displayUnitScale = displayUnit?.scaleFromNanoseconds ?? 1
         return v / Double(displayUnitScale)
     }
     

--- a/Tests/SwiftPrometheusTests/SummaryTests.swift
+++ b/Tests/SwiftPrometheusTests/SummaryTests.swift
@@ -36,7 +36,8 @@ final class SummaryTests: XCTestCase {
     
     func testSummary() {
         let summary = Timer(label: "my_summary")
-        
+        summary.handler.preferDisplayUnit(.nanoseconds)
+
         summary.recordNanoseconds(1)
         summary.recordNanoseconds(2)
         summary.recordNanoseconds(4)


### PR DESCRIPTION
A small concurrency fix for a bug introduced in https://github.com/MrLotU/SwiftPrometheus/pull/59

### Checklist
- [ + ] The provided tests still run.
- [ + ] I've created new tests where needed.
- [ N/A ] I've updated the documentation if necessary.

### Motivation and Context
just a small bug fix for thread safe access to summary `displayUnit`

### Description
I touched display unit in one of the tests so it will be caught by TSAN if it ever breaks again.
